### PR TITLE
Fix PyTorch constraints

### DIFF
--- a/backend/constraints.txt
+++ b/backend/constraints.txt
@@ -1,4 +1,4 @@
--f https://download.pytorch.org/whl/torch_stable.html 
-torch==2.3.1+cpu
-torchvision==0.18.1+cpu
-torchaudio==2.3.1+cpu
+-f https://download.pytorch.org/whl/torch_stable.html
+torch==2.2.2+cpu
+torchvision==0.17.2+cpu
+torchaudio==2.2.2+cpu


### PR DESCRIPTION
## Summary
- use torch 2.2.2 in backend constraints file

## Testing
- `pytest -q` *(fails: No module named 'requests')*